### PR TITLE
feat: Add TUI diff mode with mouse scroll and self-detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .cwt/
 
 # Go build artifacts
-./cwt
+/cwt
 main
 *.exe
 *.dll

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -427,7 +427,13 @@ func (m Model) loadDiffData() tea.Cmd {
 		}
 		defer os.Chdir(originalDir)
 
-		if err := os.Chdir(m.diffMode.session.Core.WorktreePath); err != nil {
+		// Validate that the worktree path is a git repository
+		worktreePath := m.diffMode.session.Core.WorktreePath
+		if _, err := os.Stat(filepath.Join(worktreePath, ".git")); err != nil {
+			return diffErrorMsg{err: fmt.Errorf("not a git repository: %s", worktreePath)}
+		}
+
+		if err := os.Chdir(worktreePath); err != nil {
 			return diffErrorMsg{err: fmt.Errorf("failed to change to worktree directory: %w", err)}
 		}
 

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -408,4 +411,119 @@ func (m Model) findClaudeExecutable() string {
 	}
 
 	return ""
+}
+
+// loadDiffData loads diff data for the current session
+func (m Model) loadDiffData() tea.Cmd {
+	return func() tea.Msg {
+		if m.diffMode == nil {
+			return diffErrorMsg{err: fmt.Errorf("diff mode not initialized")}
+		}
+
+		// Change to session worktree directory
+		originalDir, err := os.Getwd()
+		if err != nil {
+			return diffErrorMsg{err: fmt.Errorf("failed to get current directory: %w", err)}
+		}
+		defer os.Chdir(originalDir)
+
+		if err := os.Chdir(m.diffMode.session.Core.WorktreePath); err != nil {
+			return diffErrorMsg{err: fmt.Errorf("failed to change to worktree directory: %w", err)}
+		}
+
+		// Build git diff command
+		var cmd *exec.Cmd
+		if m.diffMode.cached {
+			cmd = exec.Command("git", "diff", "--cached", "--no-color")
+		} else {
+			cmd = exec.Command("git", "diff", m.diffMode.target, "--no-color")
+		}
+
+		output, err := cmd.Output()
+		if err != nil {
+			return diffErrorMsg{err: fmt.Errorf("failed to get diff: %w", err)}
+		}
+
+		// Parse diff output into DiffLine structures
+		diffLines := parseDiffOutput(string(output))
+		return diffLoadedMsg{diffLines: diffLines}
+	}
+}
+
+// parseDiffOutput parses git diff output into structured diff lines
+func parseDiffOutput(output string) []DiffLine {
+	lines := strings.Split(output, "\n")
+	var diffLines []DiffLine
+	var currentHunk int
+	var currentFile string
+	var oldLineNum, newLineNum int
+
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+
+		var diffLine DiffLine
+		diffLine.Content = line
+		diffLine.HunkID = currentHunk
+		diffLine.FileName = currentFile
+		diffLine.OldLine = oldLineNum
+		diffLine.NewLine = newLineNum
+
+		switch {
+		case strings.HasPrefix(line, "diff --git"):
+			diffLine.Type = DiffLineFileHeader
+			// Extract filename from diff header
+			parts := strings.Fields(line)
+			if len(parts) >= 4 {
+				currentFile = strings.TrimPrefix(parts[3], "b/")
+			}
+
+		case strings.HasPrefix(line, "index "):
+			diffLine.Type = DiffLineHeader
+
+		case strings.HasPrefix(line, "--- ") || strings.HasPrefix(line, "+++ "):
+			diffLine.Type = DiffLineHeader
+
+		case strings.HasPrefix(line, "@@"):
+			diffLine.Type = DiffLineHunkHeader
+			currentHunk++
+			// Parse line numbers from hunk header
+			if matches := regexp.MustCompile(`-(\d+)(?:,\d+)? \+(\d+)`).FindStringSubmatch(line); len(matches) >= 3 {
+				if old, err := strconv.Atoi(matches[1]); err == nil {
+					oldLineNum = old
+				}
+				if new, err := strconv.Atoi(matches[2]); err == nil {
+					newLineNum = new
+				}
+			}
+
+		case strings.HasPrefix(line, "+"):
+			diffLine.Type = DiffLineAdded
+			diffLine.NewLine = newLineNum
+			newLineNum++
+
+		case strings.HasPrefix(line, "-"):
+			diffLine.Type = DiffLineRemoved
+			diffLine.OldLine = oldLineNum
+			oldLineNum++
+
+		case strings.HasPrefix(line, " "):
+			diffLine.Type = DiffLineContext
+			diffLine.OldLine = oldLineNum
+			diffLine.NewLine = newLineNum
+			oldLineNum++
+			newLineNum++
+
+		case strings.HasPrefix(line, "\\"):
+			diffLine.Type = DiffLineNoNewline
+
+		default:
+			diffLine.Type = DiffLineContext
+		}
+
+		diffLines = append(diffLines, diffLine)
+	}
+
+	return diffLines
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -105,7 +105,6 @@ const (
 	DiffLineNoNewline
 )
 
-
 // Event messages for BubbleTea
 type (
 	// Immediate events (fsnotify)
@@ -814,7 +813,6 @@ func (m Model) handleDiffScrollDown() (Model, tea.Cmd) {
 	return m, nil
 }
 
-
 // handleShowConfirmDialog sets up a confirmation dialog
 func (m Model) handleShowConfirmDialog(msg showConfirmDialogMsg) (Model, tea.Cmd) {
 	m.confirmDialog = &ConfirmDialog{
@@ -1012,7 +1010,6 @@ func (m Model) publishSession(sessionID string) tea.Cmd {
 		}
 	}
 }
-
 
 // executeCommand executes a shell command
 func executeCommand(command string, args ...string) error {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -19,6 +19,11 @@ import (
 // Global logger for debugging
 var debugLogger *log.Logger
 
+// Constants for UI behavior
+const (
+	ScrollAmount = 10 // Number of lines to scroll in diff view
+)
+
 func init() {
 	// Create debug log file
 	logFile, err := os.OpenFile("cwt-tui-debug.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
@@ -733,7 +738,7 @@ func (m Model) handleShowDiffMode(sessionID string) (Model, tea.Cmd) {
 		session:      *session,
 		scrollOffset: 0,
 		selectedLine: 0,
-		target:       "main", // default comparison target
+		target:       "origin/main", // default comparison target
 		cached:       false,
 	}
 	m.showDiffMode = true
@@ -768,8 +773,8 @@ func (m Model) handleDiffModeKeys(msg tea.KeyMsg) (Model, tea.Cmd) {
 		return m, m.loadDiffData()
 
 	case "pgup":
-		if m.diffMode.scrollOffset > 10 {
-			m.diffMode.scrollOffset -= 10
+		if m.diffMode.scrollOffset > ScrollAmount {
+			m.diffMode.scrollOffset -= ScrollAmount
 		} else {
 			m.diffMode.scrollOffset = 0
 		}
@@ -780,8 +785,8 @@ func (m Model) handleDiffModeKeys(msg tea.KeyMsg) (Model, tea.Cmd) {
 		if maxScroll < 0 {
 			maxScroll = 0
 		}
-		if m.diffMode.scrollOffset+10 < maxScroll {
-			m.diffMode.scrollOffset += 10
+		if m.diffMode.scrollOffset+ScrollAmount < maxScroll {
+			m.diffMode.scrollOffset += ScrollAmount
 		} else {
 			m.diffMode.scrollOffset = maxScroll
 		}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -54,24 +54,24 @@ var (
 			Background(lipgloss.Color("22"))
 
 	diffRemovedStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("1")).
-			Background(lipgloss.Color("52"))
+				Foreground(lipgloss.Color("1")).
+				Background(lipgloss.Color("52"))
 
 	diffContextStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("7"))
+				Foreground(lipgloss.Color("7"))
 
 	diffFileHeaderStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(lipgloss.Color("5"))
+				Bold(true).
+				Foreground(lipgloss.Color("5"))
 
 	diffHunkHeaderStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(lipgloss.Color("6"))
+				Bold(true).
+				Foreground(lipgloss.Color("6"))
 
 	diffLineNumStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("8")).
-			Width(4).
-			Align(lipgloss.Right)
+				Foreground(lipgloss.Color("8")).
+				Width(4).
+				Align(lipgloss.Right)
 )
 
 // View renders the entire TUI
@@ -909,7 +909,7 @@ func (m Model) renderDiffMode() string {
 	lines = append(lines, "")
 
 	// Content area height calculation
-	headerLines := 3 // header + controls + blank
+	headerLines := 3                            // header + controls + blank
 	contentHeight := m.height - headerLines - 1 // minus 1 for potential bottom margin
 
 	// Render unified diff content
@@ -949,12 +949,11 @@ func (m Model) renderDiffUnified(maxLines int) []string {
 	return lines
 }
 
-
 // renderDiffLine renders a single diff line with appropriate styling
 func (m Model) renderDiffLine(line DiffLine, showLineNumbers bool) string {
 	var prefix string
 	var style lipgloss.Style
-	
+
 	switch line.Type {
 	case DiffLineAdded:
 		prefix = "+"
@@ -996,6 +995,6 @@ func (m Model) renderDiffLine(line DiffLine, showLineNumbers bool) string {
 	if lineNumStr != "" {
 		return lineNumStr + " " + prefix + style.Render(content)
 	}
-	
+
 	return prefix + style.Render(content)
 }

--- a/internal/utils/command.go
+++ b/internal/utils/command.go
@@ -1,0 +1,66 @@
+package utils
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// GetCWTCommand returns the appropriate command to run CWT based on context
+func GetCWTCommand() []string {
+	// Get the current executable path
+	executable, err := os.Executable()
+	if err == nil {
+		// Check if we're running from a temporary directory (go run)
+		if strings.Contains(executable, "go-build") || strings.Contains(executable, "/tmp/") {
+			// We're running via 'go run'
+			return []string{"go", "run", "cmd/cwt/main.go"}
+		}
+		
+		// Check if the executable name suggests it's a built binary
+		if strings.HasSuffix(executable, "/cwt") || strings.HasSuffix(executable, "\\cwt.exe") {
+			// Use the actual executable path
+			return []string{executable}
+		}
+	}
+	
+	// Fallback: check if running from source by examining os.Args
+	if len(os.Args) >= 3 && strings.Contains(os.Args[0], "go") && 
+		strings.Contains(strings.Join(os.Args[1:3], " "), "run") {
+		// We're running via 'go run cmd/cwt/main.go'
+		return []string{"go", "run", "cmd/cwt/main.go"}
+	}
+	
+	// Check if there's a 'cwt' binary in the current directory
+	if _, err := os.Stat("./cwt"); err == nil {
+		return []string{"./cwt"}
+	}
+	
+	// Check if 'cwt' is in PATH
+	if _, err := exec.LookPath("cwt"); err == nil {
+		return []string{"cwt"}
+	}
+	
+	// Final fallback: try go run (assume we're in project directory)
+	return []string{"go", "run", "cmd/cwt/main.go"}
+}
+
+// ExecuteCWTCommand executes a CWT command with proper binary detection
+func ExecuteCWTCommand(subcommand string, args ...string) error {
+	baseCmd := GetCWTCommand()
+	fullArgs := append(baseCmd[1:], subcommand)
+	fullArgs = append(fullArgs, args...)
+	
+	cmd := exec.Command(baseCmd[0], fullArgs...)
+	return cmd.Run()
+}
+
+// GetCWTExecutablePath returns just the executable path/command for CWT
+func GetCWTExecutablePath() string {
+	cmd := GetCWTCommand()
+	if len(cmd) == 1 {
+		return cmd[0]
+	}
+	// For go run, return the full command as a string
+	return strings.Join(cmd, " ")
+}

--- a/internal/utils/command.go
+++ b/internal/utils/command.go
@@ -64,4 +64,3 @@ func GetCWTExecutablePath() string {
 	// For go run, return the full command as a string
 	return strings.Join(cmd, " ")
 }
-

--- a/internal/utils/command.go
+++ b/internal/utils/command.go
@@ -16,31 +16,31 @@ func GetCWTCommand() []string {
 			// We're running via 'go run'
 			return []string{"go", "run", "cmd/cwt/main.go"}
 		}
-		
+
 		// Check if the executable name suggests it's a built binary
 		if strings.HasSuffix(executable, "/cwt") || strings.HasSuffix(executable, "\\cwt.exe") {
 			// Use the actual executable path
 			return []string{executable}
 		}
 	}
-	
+
 	// Fallback: check if running from source by examining os.Args
-	if len(os.Args) >= 3 && strings.Contains(os.Args[0], "go") && 
+	if len(os.Args) >= 3 && strings.Contains(os.Args[0], "go") &&
 		strings.Contains(strings.Join(os.Args[1:3], " "), "run") {
 		// We're running via 'go run cmd/cwt/main.go'
 		return []string{"go", "run", "cmd/cwt/main.go"}
 	}
-	
+
 	// Check if there's a 'cwt' binary in the current directory
 	if _, err := os.Stat("./cwt"); err == nil {
 		return []string{"./cwt"}
 	}
-	
+
 	// Check if 'cwt' is in PATH
 	if _, err := exec.LookPath("cwt"); err == nil {
 		return []string{"cwt"}
 	}
-	
+
 	// Final fallback: try go run (assume we're in project directory)
 	return []string{"go", "run", "cmd/cwt/main.go"}
 }
@@ -50,7 +50,7 @@ func ExecuteCWTCommand(subcommand string, args ...string) error {
 	baseCmd := GetCWTCommand()
 	fullArgs := append(baseCmd[1:], subcommand)
 	fullArgs = append(fullArgs, args...)
-	
+
 	cmd := exec.Command(baseCmd[0], fullArgs...)
 	return cmd.Run()
 }
@@ -64,3 +64,4 @@ func GetCWTExecutablePath() string {
 	// For go run, return the full command as a string
 	return strings.Join(cmd, " ")
 }
+


### PR DESCRIPTION
## 🎯 Overview

This PR adds a comprehensive diff viewing mode to the CWT TUI, along with mouse scroll support and automatic binary detection for command execution.

## ✨ Key Features

### 📋 Diff Mode
- **Access**: Press `v` on any session with changes
- **Navigation**: Scroll with `↑↓/jk`, `PgUp/PgDn`, or mouse wheel
- **Views**: Unified diff with syntax highlighting and line numbers
- **Controls**: Toggle cached/working (`c`), refresh (`r`), exit (`Esc/q`)

### 🖱️ Mouse Support
- Mouse wheel scrolling in diff mode
- Mouse wheel navigation in main session list
- Natural scrolling experience

### 🔧 Self-Detection
- Auto-detects `go run cmd/cwt/main.go` vs built binary
- Switch/merge/publish commands work in both contexts
- No more "cwt command not found" when running locally

## 🛠️ Technical Implementation

### Core Components
- **DiffMode state**: Manages scroll position and diff data
- **Git diff parsing**: Structured DiffLine types with syntax highlighting
- **Mouse events**: Bubble Tea mouse wheel support
- **Command utils**: Shared `ExecuteCWTCommand()` with detection logic

### Files Changed
- `internal/tui/model.go`: Diff mode state and event handling
- `internal/tui/view.go`: Diff rendering with lipgloss styling  
- `internal/tui/commands.go`: Git diff parsing and data loading
- `internal/utils/command.go`: Self-detection utility (new)

## 🧪 Testing

Tested with both execution methods:
- ✅ `go run cmd/cwt/main.go` (development)
- ✅ `./cwt` (built binary)

## 📸 Demo

The diff mode provides:
- Syntax highlighted additions (green background)
- Syntax highlighted deletions (red background) 
- Context lines and line numbers
- File headers and hunk headers
- Scroll indicators for long diffs

## 🔗 Related Issues

Fixes the issue where TUI commands (switch/merge/publish) failed when running with `go run` instead of a built binary.

---

Ready for review\! The diff mode makes it much easier to review changes before deciding to merge or publish sessions. 🚀