### PR TITLE
Remove task description references and add .claude to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # CWT runtime data
 .cwt/
 
+# Claude Code directory
+.claude/
+
 # Go build artifacts
 ./cwt
 main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ The SessionManager maintains an in-memory map of sessions, synchronized with:
 
 ### Available Commands
 ```bash
-cwt new [session-name] [task-description]  # Create new session  
+cwt new [session-name]                     # Create new session  
 cwt new                                     # Interactive session creation
 cwt cleanup                                 # Remove orphaned sessions/worktrees
 cwt --help                                  # Show available commands
@@ -122,7 +122,7 @@ The SessionManager centralizes all session operations:
 ### Build and Run
 ```bash
 # Run directly from source
-go run cmd/cwt/main.go new "session-name" "task description"
+go run cmd/cwt/main.go new "session-name"
 go run cmd/cwt/main.go cleanup
 
 # Build binary
@@ -135,7 +135,7 @@ go mod tidy
 ### Testing
 ```bash
 # Test basic functionality
-go run cmd/cwt/main.go new test-session "Test description"
+go run cmd/cwt/main.go new test-session
 tmux list-sessions | grep cwt    # Verify tmux session created
 git worktree list               # Verify git worktree created
 
@@ -143,7 +143,7 @@ git worktree list               # Verify git worktree created
 go run cmd/cwt/main.go cleanup
 
 # Test error scenarios
-go run cmd/cwt/main.go new test-session "Duplicate test"  # Should fail
+go run cmd/cwt/main.go new test-session  # Should fail if duplicate
 ```
 
 ### Debugging Session State

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -50,7 +50,7 @@ func runListCmd(verbose bool) error {
 
 	if len(sessions) == 0 {
 		fmt.Println("No sessions found.")
-		fmt.Println("\nCreate a new session with: cwt new [session-name] [task-description]")
+		fmt.Println("\nCreate a new session with: cwt new [session-name]")
 		return nil
 	}
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -60,7 +60,7 @@ func showEnhancedStatus(sm *state.Manager, summary, showBranch bool) error {
 
 	if len(sessions) == 0 {
 		fmt.Println("No sessions found.")
-		fmt.Println("\nCreate a new session with: cwt new [session-name] [task-description]")
+		fmt.Println("\nCreate a new session with: cwt new [session-name]")
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
• Remove task description parameter from CLI help text in `list` and `status` commands
• Update documentation examples in CLAUDE.md to remove task description references
• Add `.claude/` directory to .gitignore to exclude Claude Code settings from version control

## Test plan
- [ ] Verify `cwt list` and `cwt status` show correct help text when no sessions exist
- [ ] Confirm `.claude/` directory is no longer tracked by git
- [ ] Test that documentation examples work without task descriptions

🤖 Generated with [Claude Code](https://claude.ai/code)